### PR TITLE
NISRA 2004/2014 typo fixed upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Source: https://www.nisra.gov.uk/publications/weekly-deaths
 
 #### What is wrong with the data as presented?
 * The Usual Boilerplate (i.e. non numerical footers, non-merged multi row headers, overly complex column headers, inconsistent structure)
-* A typo in the 2014 Week Start date ([Which actually inspired me to make this repo in the first place](https://twitter.com/Bolster/status/1254017115817943041))
+* ~~a typo in the 2014 Week Start date ([Which actually inspired me to make this repo in the first place](https://twitter.com/Bolster/status/1254017115817943041))~~ ([This was fixed](https://twitter.com/NISRA/status/1254689659311054848))
 
 #### How do I use the new one
 

--- a/tests/test_tornamona.py
+++ b/tests/test_tornamona.py
@@ -2,14 +2,12 @@
 
 """Tests for `tornamona` package."""
 
+import pandas as pd
 import pytest
-
 from click.testing import CliRunner
 
-from tornamona import nisra
 from tornamona import cli
-
-import pandas as pd
+from tornamona import nisra
 
 
 @pytest.fixture
@@ -30,7 +28,7 @@ def test_content(response):
 def test_nisra_smoke():
     v = nisra.WeeklyDeaths().get().clean()
     assert v.data.shape[1] == 10, 'Should be 10 Columns Wide'
-    assert any(v.data['Week Start']==pd.to_datetime('2004-02-01')) == False, 'Found crazy 2004 date'
+    assert any(v.data['Week Start'] == pd.to_datetime('2004-02-01')) == False, 'Found crazy 2004 date'
     assert v.data.dtypes['Week Start'] == '<M8[ns]', 'Datetime column inference broken'
 
 def test_command_line_interface():

--- a/tornamona/fixes/__init__.py
+++ b/tornamona/fixes/__init__.py
@@ -1,9 +1,10 @@
+from abc import ABCMeta
 from typing import Optional, List, Union, Dict, AnyStr
 
 import pandas as pd
 
 
-class Dataset:
+class Dataset(metaclass=ABCMeta):
     fixes: List = []
     data: Optional[Union[Dict, pd.DataFrame, pd.Series]] = None
     sources: Union[AnyStr, Dict] = None
@@ -24,3 +25,7 @@ class Dataset:
             return self.data
         else:  # assume it's something concatable
             return pd.concat(self.data)
+
+    def _fix_dtypes(self):
+        """Fortunately this is super easy, barely an inconvenience, thanks to the pandas built-in 'infer_objects()'"""
+        self.data = self.data.infer_objects().reset_index(drop=True)

--- a/tornamona/fixes/nisra.py
+++ b/tornamona/fixes/nisra.py
@@ -91,27 +91,22 @@ class WeeklyDeaths(Dataset):
     def _3_2014_typo(self) -> Dataset:
         """
         There is a typo in the Week Starts column in the 2014 dataset where one week magically appears to be 2004
+
+        This was resolved 2020-04-27 https://twitter.com/NISRA/status/1254689659311054848
         :return:
         """
-        if not any(self.data['Week Start'] == pd.to_datetime('2004-02-01')):
-            raise ValueError("Can't find broken value, this fix has possibly been resolved!")
-
-        self.data.loc[
-            self.data['Week Start'] == pd.to_datetime('2004-02-01'),
-            'Week Start'
-        ] = pd.to_datetime('2014-02-01')
+        if any(self.data['Week Start'] == pd.to_datetime('2004-02-01')):
+            self.data.loc[
+                self.data['Week Start'] == pd.to_datetime('2004-02-01'),
+                'Week Start'
+            ] = pd.to_datetime('2014-02-01')
 
         return self
-
-    def _4_fix_dtypes(self) -> Dataset:
-        """Fortunately this is super easy, barely an inconvenience, thanks to the pandas built-in 'infer_objects()'"""
-        self.data = self.data.infer_objects().reset_index(drop=True)
 
     def clean(self) -> Dataset:
         self._0_strip_irrelevant_sheets()
         self._1_dump_first_3_rows_and_rename_columns()
         self._2_concat_and_dropna()
-        self._3_2014_typo()
-        self._4_fix_dtypes()
+        self._fix_dtypes()
 
         return self


### PR DESCRIPTION
NISRA [fixed](https://twitter.com/NISRA/status/1254689659311054848) this upstream data issue.
Also moved the _fix_dtypes into the `Dataset` superclass as it's pretty generic at this point.